### PR TITLE
Provide a proper package framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,32 +1,3 @@
-# Compiled Object files
-*.slo
-*.lo
-*.o
-*.obj
-
-# Precompiled Headers
-*.gch
-*.pch
-
-# Compiled Dynamic libraries
-*.so
-*.dylib
-*.dll
-
-# Fortran module files
-*.mod
-
-# Compiled Static libraries
-*.lai
-*.la
-*.a
-*.lib
-
-# Executables
-*.exe
-*.out
-*.app
-
 # VIM swap files
 *.s??
 /.stack-work/

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@
 
 # VIM swap files
 *.swp
+/.stack-work/

--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,5 @@
 *.app
 
 # VIM swap files
-*.swp
+*.s??
 /.stack-work/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # libstep
+
 STEP file reading/writing library
 
-STEP described in ISO standard (ISO 10303-21) or russian GOST (ГОСТ ИСО 10303-21).
+STEP is described in ISO standard (ISO 10303-21) and Russian GOST (ГОСТ ИСО
+10303-21). Implementors of this library used GOST specification as a reference.

--- a/Setup.hs
+++ b/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/libstep.cabal
+++ b/libstep.cabal
@@ -1,0 +1,44 @@
+name:                libstep
+version:             0.1.0.0
+synopsis:            Read and write STEP files
+description:
+ STEP files can represent 3D objects in computer-aided design and related
+ information. This package provides functions to read EXPRESS schemas and
+ STEP objects described according to them, and also functions to construct and
+ write new STEP objects.
+homepage:            https://github.com/Newlifer/libstep#readme
+license:             MIT
+license-file:        LICENSE
+author:              Alex Novozhilov
+maintainer:          Alex Novozhilov, Alexander Batischev <eual.jp@gmail.com>
+copyright:           2015 Alex Novozhilov, Alexander Batischev
+category:            File
+build-type:          Simple
+-- extra-source-files:
+cabal-version:       >=1.10
+
+library
+  hs-source-dirs:      src
+  exposed-modules:     Step
+  build-depends:       base >= 4.7 && < 5
+                     , attoparsec
+  default-language:    Haskell2010
+
+test-suite libstep-test
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      test
+  main-is:             test.hs
+  build-depends:       base
+                     , libstep
+
+                     , attoparsec
+                     , bytestring
+                     , hspec-attoparsec
+                     , tasty
+                     , tasty-hspec
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
+  default-language:    Haskell2010
+
+source-repository head
+  type:     git
+  location: https://github.com/Newlifer/libstep

--- a/src/Step.hs
+++ b/src/Step.hs
@@ -1,10 +1,15 @@
 {-# LANGUAGE OverloadedStrings #-}
-module Express where
+module Step (
+  Vector(..)
+
+, parseStep
+) where
 
 import Data.Attoparsec.ByteString.Char8
 import Data.Word
 
-data Vector = Vector [Double] deriving Show
+data Vector = Vector [Double]
+  deriving (Show, Eq)
 
 delimiter :: Char
 delimiter = ','
@@ -34,3 +39,6 @@ parseVector = do
     result <- parseVectorElement `sepBy` (char delimiter)
     char groupFinish
     return $ Vector result
+
+parseStep :: Parser Vector
+parseStep = parseVector

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,5 @@
+flags: {}
+packages:
+- '.'
+extra-deps: []
+resolver: lts-3.15

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-import Express
+import Step
 import Data.Attoparsec.ByteString.Char8
 
 main :: IO ()

--- a/test/test.hs
+++ b/test/test.hs
@@ -1,0 +1,24 @@
+import Test.Hspec.Attoparsec
+import Test.Tasty
+import Test.Tasty.Hspec
+
+import Data.Attoparsec.ByteString.Char8
+import qualified Data.ByteString.Char8 as C8
+
+import Step
+
+main :: IO ()
+main = do
+  specs <- createSpecs
+  let tests = testGroup "Tests" [specs]
+  defaultMain tests
+
+createSpecs = testSpec "Parsing" $ parallel $
+  describe "success cases" $ do
+    it "should parse case1" $
+      (C8.pack "(  1.45  , 666.    ,2.   ,6.022E23)") ~> parseStep
+        `shouldParse` (Vector [1.45, 666.0, 2.0, 6.022e23])
+
+    it "should parse case2" $
+      (C8.pack "(1.0,2.0,3.0,4.0)") ~> parseStep
+        `shouldParse` (Vector [1.0, 2.0, 3.0, 4.0])


### PR DESCRIPTION
In these commits I:
- put existing code into Cabal package;
- added `stack.yaml` so that package can be build with stack;
- cleaned `.gitignore` from stuff that we don't really need to ignore.

**Now** we're ready to roll!
