### PR TITLE
Cleaning up after #1

### DIFF
--- a/libstep.cabal
+++ b/libstep.cabal
@@ -19,7 +19,8 @@ cabal-version:       >=1.10
 
 library
   hs-source-dirs:      src
-  exposed-modules:     Step
+  exposed-modules:     Data.STEP
+                     , Data.STEP.Parsers
   build-depends:       base >= 4.7 && < 5
                      , attoparsec
   default-language:    Haskell2010

--- a/src/Data/EXPRESS.hs
+++ b/src/Data/EXPRESS.hs
@@ -1,0 +1,2 @@
+module Data.EXPRESS (
+) where

--- a/src/Data/EXPRESS/Parsers.hs
+++ b/src/Data/EXPRESS/Parsers.hs
@@ -1,0 +1,2 @@
+module Data.EXPRESS.Parsers (
+) where

--- a/src/Data/STEP.hs
+++ b/src/Data/STEP.hs
@@ -1,0 +1,2 @@
+module Data.STEP (
+) where

--- a/src/Data/STEP/Parsers.hs
+++ b/src/Data/STEP/Parsers.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-module Step (
+module Data.STEP.Parsers (
   Vector(..)
 
 , parseStep

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,7 +1,0 @@
-{-# LANGUAGE OverloadedStrings #-}
-import Step
-import Data.Attoparsec.ByteString.Char8
-
-main :: IO ()
-main = print $ parseOnly parseVector "(  1.45  , 666.    ,2.   ,6.022E23)"
-{-main = print $ parseOnly parseVector "(1.0,2.0,3.0,4.0)"-}

--- a/test/test.hs
+++ b/test/test.hs
@@ -5,7 +5,7 @@ import Test.Tasty.Hspec
 import Data.Attoparsec.ByteString.Char8
 import qualified Data.ByteString.Char8 as C8
 
-import Step
+import Data.STEP.Parsers
 
 main :: IO ()
 main = do


### PR DESCRIPTION
Sorry, I just realized that in my previous PR, I screwed up a bit, namely:
- I didn't remove your `Main.hs` from `test` directory;
- I created a package that doesn't use proper file structure and module names.

This PR fixes both of those issues.

Please note that I did create `Data.EXPRESS`, but I didn't export it. Why, you say? Glad you asked! Since we don't _really_ implement full-fledged EXPRESS parsers, exporting them would be just module names space pollution (IMHO). But that also means we can't directly test them. After a bit of experimenting I decided that it's probably too early to worry about this, though, so let's leave it at that for now.
